### PR TITLE
Add a link to K8s in the docs now that it's publicly available

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -7,7 +7,7 @@
 - ⚡️ **Lightning Fast.** Starts in 2 seconds, optimized networking (35 Gbps) and disk, Rosetta x86 emulation.
 - 💨 **Feather Light.** Low CPU and disk usage, works with less memory, native Swift app, battery-friendly.
 - 🍰 **Effortlessly Simple.** Minimal setup, 2-way CLI integration & file access, VPN support and remote VS Code, SSH agent forwarding.
-- ⚙️ **Powerful.** Run Docker containers and full Linux distros (soon Kubernetes) seamlessly with robust networking. Manage containers from anywhere with our menu bar app.
+- ⚙️ **Powerful.** Run Docker containers, full Linux distros and [Kubernetes](https://docs.orbstack.dev/kubernetes/) seamlessly with robust networking. Manage containers from anywhere with our menu bar app.
 
 Check the [website](https://orbstack.dev) for demos, or see [what we're up to](https://docs.orbstack.dev/release-notes).
 


### PR DESCRIPTION
Now that [OrbStack 0.17.0](https://twitter.com/OrbStack/status/1696431454434062745) added support for k8s, you forgot to update the OrbStack GitHub page to mention this.

This fixes that.

As always, great work @kdrag0n 👍!